### PR TITLE
Stop changes in plant orientation

### DIFF
--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -10,17 +10,21 @@ import pandas as pd
 import numpy as np
 
 import sys
-import os, os.path
+import os
 import uuid
 import json
 
-from walter import data_access
-from os.path import join as pj
+
+pj = os.path.join
 data_dir = os.getcwd()
 inputdir = pj(data_dir, 'input')
 #from my_own_functions import *
 
-
+# setup params if and only if not defined as Lsys args
+try:
+  params = params
+except NameError:
+  params = {}
 
 # create a fake lsystem for forcing cuting branchs in end eac (see tes_cut_module.py)
 lpy_cut_bug = True
@@ -78,12 +82,7 @@ module CutPointBud
 module CutPointBlade
 
 ### REPRESENTATION DES ORGANES
-# params = dict(map(lambda x: x.split('='), sys.argv[1:]))
-# for key, item in params.items():
-#     try :
-#         params[key] = float(item)
-#     except:
-#         pass
+
 
 #Param�tres de mise � l'�chelle pour que 1=1 dans chacune des directions
 scalex = 0.5
@@ -116,11 +115,22 @@ for key, value, in params.iteritems():
   if key in var_register1:
     exec(key+"=value")
 
-hazard_driver = {"plant" : True, "axis" : True, "organ" : True, "emerg" : True}
-hazard_plant = hazard_driver["plant"]
-hazard_axis = hazard_driver["axis"]
-hazard_organ = hazard_driver["organ"]
-hazard_emerg = hazard_driver["emerg"]
+
+hazard_plant_xy = True
+hazard_plant_azi = True
+hazard_axis = True
+hazard_organ = True
+hazard_emerg = True
+
+var_register_hazard = ["hazard_plant_xy","hazard_plant_azi","hazard_axis","hazard_organ","hazard_emerg"]
+
+for key, value, in params.iteritems():
+  if key in var_register_hazard:
+    exec(key+"=value")
+
+
+hazard_driver = {"plant_azi" : hazard_plant_azi, "plant_xy" : hazard_plant_xy, "axis" : hazard_axis, "organ" : hazard_organ, "emerg" : hazard_emerg}
+
 
 write_lscene = False
 write_lstring = False
@@ -657,15 +667,17 @@ Phi_zen_S = 0         # Angle between seed inclination and Y axis | old name : s
 # hazard_driver dictionnary will trigger if necessary hazard in different cases:
 # if hazard == False : hazard parameter value = 0, if hazard == True, hazard parameter value is set at the value of the parameter
 
-y_position_hazard = int(hazard_driver["plant"]) * 2
-x_position_hazard = int(hazard_driver["plant"]) * 3
-z_position_hazard = int(hazard_driver["plant"]) * 0
+y_position_hazard = int(hazard_driver["plant_xy"]) * 2
+x_position_hazard = int(hazard_driver["plant_xy"]) * 3
+z_position_hazard = int(hazard_driver["plant_xy"]) * 0
 
 blade_incl_hazard = int(hazard_driver["organ"]) * 5
 blade_azi_hazard = int(hazard_driver["organ"]) * 20
 
 till_zen_hazard = int(hazard_driver["axis"]) * 7
 till_azi_hazard = int(hazard_driver["axis"]) * 90
+
+plant_azi_hazard = int(hazard_driver["plant_azi"]) * 360
 
 
 ## SELF-ORGANIZED TILLERING RULES
@@ -1786,7 +1798,7 @@ latitude           = dico_latitudes[location]
 
 meteo_dF = pd.read_csv(pj(inputdir, "meteo", location + ".csv"), header=9, sep=";")
 
-var_register = ["crop_ccptn","sowing_date","year","latitude","nbj","densite","nb_rang","nb_plantes","area_targeted","geno_nb","SIRIUS_state","infinity_GAIp","nb_azimuth","nb_zenith","dist_inter_rang","hazard_plant","hazard_axis","hazard_organ","hazard_emerg","N_p_s","l_c","L_b_S","Psi_FT","param_Ln_final","Tbase","Tvermin","Tverint","Tvermax","Lmax","Lmin","Ldecr","Lincr","phyllo_decr","phyllo_incr","DLsat","Delta_b","dGAIp","Delta_l","Delta_c_GN","Delta_hf","Delta_hm","Delta_lflf","Delta_flsp","Delta_SGtR","Delta_SGtC","ED_I","ED_B","ED_FB","ED_S","Phi_zen_B","Phi_azi_B","Phi_zen_T","Phi_azi_T","Phi_zen_E","Phi_azi_S","Phi_zen_S","y_position_hazard","x_position_hazard","z_position_hazard","blade_incl_hazard","blade_azi_hazard","till_zen_hazard","till_azi_hazard","Phl_Soissons","Phl_Maxwell","VAI_Soissons","VAI_Maxwell","VBEE_Soissons","VBEE_Maxwell","SLDL_Soissons","SLDL_Maxwell","N_I_el_Soissons","N_I_el_Maxwell","s_B_1_Soissons","s_B_1_Maxwell","N_B_r_Soissons","N_B_r_Maxwell","L_B_1_Soissons","L_B_1_Maxwell","L_B_max_Soissons","L_B_max_Maxwell","s_B_f_Soissons","s_B_f_Maxwell","a_B_w_Soissons","a_B_w_Maxwell","b_B_w_Soissons","b_B_w_Maxwell","a_S_L_Soissons","a_S_L_Gigant_Maxwell","a_S_L_Maxwell","b_S_L_Soissons","b_S_L_Gigant_Maxwell","b_S_L_Maxwell","inc_I_Soissons","inc_I_Maxwell","b_I_L_Soissons","b_I_L_Maxwell","b_I_L_Gigant_Maxwell","a_I_L_Soissons","a_I_L_MAxwell","a_I_L_Gigant_Maxwell","d_I_Soissons","d_I_Maxwell","L_P_Soissons","L_P_Maxwell","d_P_Soissons","d_P_Maxwell","d_E_Soissons","d_E_Maxwell","L_E_Soissons","L_E_Maxwell","d_S_Soissons","d_S_Maxwell","n0_sen_Soissons","n0_sen_Maxwell","n1_sen_Soissons","n1_sen_Maxwell","n2_sen_Soissons","n2_sen_Maxwell","n3_sen_Soissons","n3_sen_Maxwell","t0_sen_Soissons","t0_sen_Maxwell","t1_sen_Soissons","t1_sen_Maxwell","t2_sen_Soissons","t2_sen_Maxwell","t3_sen_Soissons","t3_sen_Maxwell","P_CT_Soissons","P_CT_Maxwell","P_T_Soissons","P_T_Maxwell","nb_plt_utiles","dist_border_x","dist_border_y","nb_plt_temp"]
+var_register = ["crop_ccptn","sowing_date","year","latitude","nbj","densite","nb_rang","nb_plantes","area_targeted","geno_nb","SIRIUS_state","infinity_GAIp","nb_azimuth","nb_zenith","dist_inter_rang","hazard_axis","hazard_organ","hazard_emerg","N_p_s","l_c","L_b_S","Psi_FT","param_Ln_final","Tbase","Tvermin","Tverint","Tvermax","Lmax","Lmin","Ldecr","Lincr","phyllo_decr","phyllo_incr","DLsat","Delta_b","dGAIp","Delta_l","Delta_c_GN","Delta_hf","Delta_hm","Delta_lflf","Delta_flsp","Delta_SGtR","Delta_SGtC","ED_I","ED_B","ED_FB","ED_S","Phi_zen_B","Phi_azi_B","Phi_zen_T","Phi_azi_T","Phi_zen_E","Phi_azi_S","Phi_zen_S","y_position_hazard","x_position_hazard","z_position_hazard","blade_incl_hazard","blade_azi_hazard","till_zen_hazard","till_azi_hazard","Phl_Soissons","Phl_Maxwell","VAI_Soissons","VAI_Maxwell","VBEE_Soissons","VBEE_Maxwell","SLDL_Soissons","SLDL_Maxwell","N_I_el_Soissons","N_I_el_Maxwell","s_B_1_Soissons","s_B_1_Maxwell","N_B_r_Soissons","N_B_r_Maxwell","L_B_1_Soissons","L_B_1_Maxwell","L_B_max_Soissons","L_B_max_Maxwell","s_B_f_Soissons","s_B_f_Maxwell","a_B_w_Soissons","a_B_w_Maxwell","b_B_w_Soissons","b_B_w_Maxwell","a_S_L_Soissons","a_S_L_Gigant_Maxwell","a_S_L_Maxwell","b_S_L_Soissons","b_S_L_Gigant_Maxwell","b_S_L_Maxwell","inc_I_Soissons","inc_I_Maxwell","b_I_L_Soissons","b_I_L_Maxwell","b_I_L_Gigant_Maxwell","a_I_L_Soissons","a_I_L_MAxwell","a_I_L_Gigant_Maxwell","d_I_Soissons","d_I_Maxwell","L_P_Soissons","L_P_Maxwell","d_P_Soissons","d_P_Maxwell","d_E_Soissons","d_E_Maxwell","L_E_Soissons","L_E_Maxwell","d_S_Soissons","d_S_Maxwell","n0_sen_Soissons","n0_sen_Maxwell","n1_sen_Soissons","n1_sen_Maxwell","n2_sen_Soissons","n2_sen_Maxwell","n3_sen_Soissons","n3_sen_Maxwell","t0_sen_Soissons","t0_sen_Maxwell","t1_sen_Soissons","t1_sen_Maxwell","t2_sen_Soissons","t2_sen_Maxwell","t3_sen_Soissons","t3_sen_Maxwell","P_CT_Soissons","P_CT_Maxwell","P_T_Soissons","P_T_Maxwell","nb_plt_utiles","dist_border_x","dist_border_y","nb_plt_temp"]
 
 print 'parms'
 print params
@@ -2455,10 +2467,11 @@ def End(lstring):
                        "dist_intra_rang" + "\t" + "All" + "\t" + "%s" % dist_intra_rang + "\n" +
                        "dx" + "\t" + "All" + "\t" + "%s" % dx  + "\n" +
                        "dy" + "\t" + "All" + "\t" + "%s" % dy  + "\n" +
-                       "Hazard_plant" + "\t" + "All" + "\t" + "%s" % hazard_plant  + "\n" +
-                       "Hazard_axis" + "\t" + "All" + "\t" + "%s" % hazard_axis  + "\n" +
-                       "Hazard_organ" + "\t" + "All" + "\t" + "%s" % hazard_organ  + "\n" +
-                       "Hazard_emerg" + "\t" + "All" + "\t" + "%s" % hazard_emerg  + "\n" +
+                       "Hazard_plant_xy" + "\t" + "All" + "\t" + "%s" % hazard_driver["plant_xy"]  + "\n" +
+                       "Hazard_plant_azi" + "\t" + "All" + "\t" + "%s" % hazard_driver["plant_azi"]  + "\n" +
+                       "Hazard_axis" + "\t" + "All" + "\t" + "%s" % hazard_driver["axis"]  + "\n" +
+                       "Hazard_organ" + "\t" + "All" + "\t" + "%s" % hazard_driver["organ"]  + "\n" +
+                       "Hazard_emerg" + "\t" + "All" + "\t" + "%s" % hazard_driver["emerg"]  + "\n" +
                        "N_p_s" + "\t" + "All" + "\t" + "%s" % N_p_s + "\n" +
                        "l_c" + "\t" + "%s" % "All" + "\t" + "%s" % l_c + "\n" +
                        "L_b_S" + "\t" + "All" + "\t" + "%s" % L_b_S + "\n" +
@@ -2670,7 +2683,7 @@ Seed:
     dico_cut_dead_blades[num_plante][tiller_init] = []
     
     hazard_dict_axis[num_plante] = {}
-    hazard_dict_axis[num_plante][tiller_init] = {"tiller_azimuth" : Phi_azi_S , "tiller_zenith" : Phi_zen_S}
+    hazard_dict_axis[num_plante][tiller_init] = {"tiller_azimuth" : Phi_azi_S + random.randint(0,plant_azi_hazard) , "tiller_zenith" : Phi_zen_S}
     
     ### about initiated organs
     date_emission[num_plante] = {}
@@ -2737,18 +2750,14 @@ Seed:
       earliest_plant = key
     if value == maximal_emergence:
       latest_plant = key
-  
-  #List phyllochrones of all the genotypes presents within the crop
+  # List phyllochrones of all the genotypes presents within the crop
   all_phyllo = {}
   for g in crop_genotype:
     all_phyllo[phyll_adjust(g)] = g
-  
   longest_phyllo = max(all_phyllo.keys())
   shortest_phyllo = min(all_phyllo.keys())
-
   earliest_geno = all_phyllo[shortest_phyllo]
   latest_geno = all_phyllo[longest_phyllo]
-
   if 'beginning_CARIBU' in params:
     beginning_CARIBU = params['beginning_CARIBU']
   else:
@@ -4085,7 +4094,7 @@ CutPointBud(StCPB):
   #if StCPB.tiller == (1,) or StCPB.tiller == (1,2):
     #print "axe : ", StCPB.tiller, "zen : ", StCPB.zenith, "azi : ", StCPB.azimuth
   if StCPB.tiller == (1,):
-	produce @R/(StCPB.azimuth)+(StCPB.zenith)F(0.01)
+    produce @R/(StCPB.azimuth)+(StCPB.zenith)F(0.01)
   else:
     produce /(StCPB.azimuth)+(StCPB.zenith)F(0.01)
 

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -4084,7 +4084,10 @@ CutPointBud(StCPB):
     #print "zen : ", StCPB.zenith, "azi : ",StCPB.azimuth
   #if StCPB.tiller == (1,) or StCPB.tiller == (1,2):
     #print "axe : ", StCPB.tiller, "zen : ", StCPB.zenith, "azi : ", StCPB.azimuth
-  produce /(StCPB.azimuth)+(StCPB.zenith)F(0.01)
+  if StCPB.tiller == (1,):
+	produce @R/(StCPB.azimuth)+(StCPB.zenith)F(0.01)
+  else:
+    produce /(StCPB.azimuth)+(StCPB.zenith)F(0.01)
 
 endlsystem
 ###### INITIALISATION ######


### PR DESCRIPTION
Reset of the orientation of the turtle each time the model draws a new plant : it prevents plants from changing orientation from one day to another
This will partially solve the issue #12 . We still need to add random to the orientation of plants, otherwise, they are all oriented in the same direction.