### PR TITLE
Write GAI.csv

### DIFF
--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -834,8 +834,8 @@ real_ts0 = [float("inf")]
 
 ### PANDAS DATAFRAME ###
 
+global GAI_dico_df
 if CARIBU_state == "enabled":
-  global GAI_dico_df
   GAI_dico_df = {"Init_flag":[], "Elapsed_time":[],"Temp_cum":[],"DOY":[],"Genotype":[],"Num_plante":[],"Surface_plante":[],"Surface_visible":[],"Surface_sol":[],"GAI_tot":[],"GAI_center":[],"GAI_ind":[],"GAI_prox":[],"Position":[], "Weakest_axis":[],"PAR_weakest_axis":[]}
 if CARIBU_state == "disabled":
   GAI_dico_df = {"Init_flag":[], "Elapsed_time":[],"Temp_cum":[],"DOY":[],"Genotype":[],"Num_plante":[],"Surface_plante":[],"Surface_visible":[],"Surface_sol":[],"GAI_tot":[],"GAI_center":[],"GAI_ind":[],"GAI_prox":[],"Position":[]}

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -834,8 +834,11 @@ real_ts0 = [float("inf")]
 
 ### PANDAS DATAFRAME ###
 
-global GAI_dico_df
-GAI_dico_df = {"Init_flag":[], "Elapsed_time":[],"Temp_cum":[],"DOY":[],"Genotype":[],"Num_plante":[],"Surface_plante":[],"Surface_visible":[],"Surface_sol":[],"GAI_tot":[],"GAI_center":[],"GAI_ind":[],"GAI_prox":[],"Position":[], "Weakest_axis":[],"PAR_weakest_axis":[]}
+if CARIBU_state == "enabled":
+  global GAI_dico_df
+  GAI_dico_df = {"Init_flag":[], "Elapsed_time":[],"Temp_cum":[],"DOY":[],"Genotype":[],"Num_plante":[],"Surface_plante":[],"Surface_visible":[],"Surface_sol":[],"GAI_tot":[],"GAI_center":[],"GAI_ind":[],"GAI_prox":[],"Position":[], "Weakest_axis":[],"PAR_weakest_axis":[]}
+if CARIBU_state == "disabled":
+  GAI_dico_df = {"Init_flag":[], "Elapsed_time":[],"Temp_cum":[],"DOY":[],"Genotype":[],"Num_plante":[],"Surface_plante":[],"Surface_visible":[],"Surface_sol":[],"GAI_tot":[],"GAI_center":[],"GAI_ind":[],"GAI_prox":[],"Position":[]}
 
 global Apex_Sirius_dico_df
 Apex_Sirius_dico_df = {"Elapsed_time" :[],"Temperature" :[],"Temp_cum" :[], "Daylength" :[], "Num_plante" :[], "Genotype" :[], "PN"  :[], "LN"  :[], "Sumtemp"   :[], "Vern_rate" :[], "Vern_prog" :[], "Vern_flag" :[], "Debut_ppd_flag" :[], "Fin_ppd_flag" :[], "Ln_pot" :[], "Var_L_min" :[],"Ln_app" :[], "Ln_final" :[]}

--- a/test/test_simu1.py
+++ b/test/test_simu1.py
@@ -40,4 +40,22 @@ def test_simu2():
     p.remove(force=True)
 
 
+def test_simu3():
+
+    def run_one_simu(p, param_dict):
+        lsys, lstring = p.run(**param_dict)
+
+        assert len(lstring) > 10
+        s = lsys.sceneInterpretation(lstring)
+        assert len(s) > 2
+
+    p = project.Project(name='simu_test3')
+    params = p.csv_parameters('sim_scheme_test.csv')
+
+    outs = p.which_outputs
+    p.which_outputs = outs
+    for param_dict in params:
+        yield run_one_simu, p, param_dict
+    p.deactivate()
+    p.remove(force=True)
 


### PR DESCRIPTION
Solving issue #19 . Adding a test : if CARIBU is disabled, the GAI.csv output files does not contain information on the intercepted PAR.