### PR TITLE
Adapting the randomness in plant position to the type of sowing spatial arrangement

### DIFF
--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -748,7 +748,12 @@ Phi_zen_S = 0         # Angle between seed inclination and Y axis | old name : s
 # if hazard == False : hazard parameter value = 0, if hazard == True, hazard parameter value is set at the value of the parameter
 
 y_position_hazard = int(hazard_driver["plant_xy"]) * 2
-x_position_hazard = int(hazard_driver["plant_xy"]) * 3
+
+if crop_ccptn == "Mesh_for_nplants" or crop_ccptn == "Darwinkel_original":
+  x_position_hazard = int(hazard_driver["plant_xy"]) * 2
+else:
+  x_position_hazard = int(hazard_driver["plant_xy"]) * 3
+
 z_position_hazard = int(hazard_driver["plant_xy"]) * 0
 
 blade_incl_hazard = int(hazard_driver["organ"]) * 5


### PR DESCRIPTION
Adding a condition for the plant_xy_hazard : if the crop_ccptn is a mesh, plant_x_hazard = plant_y_hazard, otherwise plant_x_hazard > plant_y_hazard (more randomness for the position of the plants inside the rank than between ranks)