### PR TITLE
remove lpy cut bug management 

### DIFF
--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -26,20 +26,6 @@ try:
 except NameError:
   params = {}
 
-# create a fake lsystem for forcing cuting branchs in end eac (see tes_cut_module.py)
-lpy_cut_bug = False
-if lpy_cut_bug:
-  from openalea.lpy import Lsystem
-  fake_rule = """
-  Fake:
-    produce Fake"""
-  fake_lsys = Lsystem()
-  fake_lsys.addRule(fake_rule)
-
-  def force_cut(lstring):
-    fake_lsys.axiom = lstring
-    return fake_lsys.iterate()
-
 
 ### Importations de fichiers annexes ###
 
@@ -2153,10 +2139,7 @@ def StartEach(lstring):
 
 
 def EndEach(lstring, lscene):
-  global lpy_cut_bug
-  if lpy_cut_bug:
-    # Force removal of cut branches to have a consistent indexing between lscene and lstring (see test_cut_module.py)
-    lstring = force_cut(lstring)
+
   # CALCUL DU GAI (� partir de la chaine)
   for num_plt in range(1, crop_scheme["nplant_peupl"] + 1):
     Hcol_max[num_plt] = dict.fromkeys(Hcol_max[num_plt].keys(), 0)

--- a/test/test_cut_module.py
+++ b/test/test_cut_module.py
@@ -4,23 +4,28 @@ from os.path import join as pj
 from openalea.lpy import Lsystem
 from walter import data_access
 
-fake_rule = """
-Fake:
-  produce Fake"""
+
+def force_cut(lstring):
+    fake_rule = """
+    Fake:
+      produce Fake"""
+    fake_lsys = Lsystem()
+    fake_lsys.addRule(fake_rule)
+    fake_lsys.axiom = lstring
+    return fake_lsys.iterate()
+
 
 def test_cut_bug():
     lsystem_file = pj(data_access.get_data_dir(), 'check_cut_module.lpy')
     lsys = Lsystem(lsystem_file)
     lstring = lsys.iterate()
     # cut branches
-    fake_lsys = Lsystem()
-    fake_lsys.addRule(fake_rule)
-    fake_lsys.axiom = lstring
-    new_lstring = fake_lsys.iterate()
+    new_lstring = force_cut(lstring)
     lscene = lsys.sceneInterpretation(lstring)
     for sid in lscene.todict():
         assert sid in range(len(lstring))
-        # suucceed if correction is needed
+        # suucceed if correction is needed (old lpy version)
         # assert new_lstring[sid].name == 'Internode'
-        #  succeed if lpy bug has been fixed
+        #  succeed on more recent lpy version
         assert lstring[sid].name == 'Internode'
+        # if correction is needed force_cut has to be applied in EndEach on lstring to get matching ids with lscene


### PR DESCRIPTION
remove lpy cut bug management from  WALTer.lpy (close #39)
keep testing if an error-prone version of lpy is installed