### PR TITLE
Caribu run error

### DIFF
--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -87,7 +87,11 @@ def main():
                     tmp.mkdir()
                 pids = []
                 procs = {}
+                active_procs = []
                 for i, pdict in enumerate(param_list):
+                    while len(active_procs) > 2: # As long as there are 3 active_procs, test if one ends
+                        active_procs = [proc for proc in active_procs if proc.poll() == None]
+                        time.sleep(300) # To avoid testing for finished processes too often, wait 5 minutes between loops
                     df = pd.DataFrame.from_dict(data=[pdict], orient='columns')
                     scheme_name = str(tmp / 'sim_scheme_%d.csv' % (i + 1))
                     df.to_csv(path_or_buf=scheme_name, sep='\t', index=False)
@@ -95,6 +99,7 @@ def main():
                     pid = Popen(["walter", "-i", scheme_name])
                     pids.append(pid)
                     procs[scheme_name] = pid
+                    active_procs.append(pid)
                 # Test caribuRunError re-launching
                 while len(procs) > 0: # While there are processes to test
                     for scheme in procs.keys(): #Not using iteritems because you cannot change the size of a dictionary while iterating on it
@@ -113,6 +118,6 @@ def main():
                                 prj.update_itable()
                                 pids.append(p) # Add the new process to the list of processes for futher testing
                                 procs[scheme] = p # Add the new process to the dict of processes
-                    time.sleep(20) # To avoid testing for finished processes too often, wait 2 minutes between loops
+                    time.sleep(120) # To avoid testing for finished processes too often, wait 2 minutes between loops
                 tmp.rmtree()
 

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -5,6 +5,7 @@
 import argparse
 from subprocess import Popen
 import pandas as pd
+import time
 
 from walter import project
 
@@ -99,7 +100,7 @@ def main():
                             sim_id = prj.get_id(param_list_dict[0]) # Get the ID
                             if os.path.exists(prj.dirname/output/sim_id/error_caribu.txt): # Check if the file error_caribu.txt has been generated
                                 ex_rep = param_list_dict[0]["rep"] # Get the rep (random seed) used for the simulation
-                                param_list_dict[0].update(rep = ex_rep +1)) # Update the sim_scheme with a new seed to re-launch the simulation
+                                param_list_dict[0].update(rep = ex_rep +1) # Update the sim_scheme with a new seed to re-launch the simulation
                                 df = pd.DataFrame.from_dict(data=param_list_dict, orient='columns')
                                 df.to_csv(path_or_buf=scheme, sep='\t', index=False) # Create the csv file sim_scheme to launch the simulation
                                 p = Popen(["walter", "-i", scheme]) # Launch the simulation
@@ -107,7 +108,7 @@ def main():
                                 prj.update_itable()
                                 pids.append(p) # Add the new process to the list of processes for futher testing
                                 procs[scheme] = p # Add the new process to the dict of processes
-                    sleep 1 minute # To avoid testing for finished processes too often, wait between loops
+                    time.sleep(120) # To avoid testing for finished processes too often, wait 2 minutes between loops
                                 
                 tmp.rmtree()
 

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -89,28 +89,25 @@ def main():
                     prj.activate()
                     pid = Popen(["walter", "-i", scheme_name])
                     pids.append(pid)
-                    procs[pid] = scheme_name
-                for pid in pids:
-                    pid.wait()
-                #~ # Test caribuRunError re-launching
-                #~ while len(procs) > 0:
-                    #~ for proc, scheme in procs.iteritems:
-                        #if proc.poll() != None:
-                            # remove this proc from procs
-                            #procs.pop(proc)
-                            #param_list_dict = prj.csv_parameters(scheme)
-                            # Recupere ID
-                            #sim_id = prj.get_id(param_list_dict[0])
-                            #if os.path.exists(prj.dirname/output/sim_id/error_caribu.txt): # Check if the file error_caribu.txt has been generated
-                                #ex_rep = param_list_dict[0]["rep"]
-                                #param_list_dict[0].update(rep = ex_rep +1))
-                                #df = pd.DataFrame.from_dict(data=param_list_dict, orient='columns')
-                                #df.to_csv(path_or_buf=scheme, sep='\t', index=False)
-                                #p=popen(["walter", "-i", scheme])
-                                #prj.itable.update(sim_id=param_list_dict[0])
-                                #prj.update_itable()
-                                #procs.append(p)
-                    #sleep 1 minute
+                    procs[scheme_name] = pid
+                # Test caribuRunError re-launching
+                while len(procs) > 0: # While there are processes to test
+                    for scheme, proc in procs.iteritems:
+                        if proc.poll() != None: # If the proces is finished
+                            procs.pop(proc) # Remove this proc from procs
+                            param_list_dict = prj.csv_parameters(scheme)
+                            sim_id = prj.get_id(param_list_dict[0]) # Get the ID
+                            if os.path.exists(prj.dirname/output/sim_id/error_caribu.txt): # Check if the file error_caribu.txt has been generated
+                                ex_rep = param_list_dict[0]["rep"] # Get the rep (random seed) used for the simulation
+                                param_list_dict[0].update(rep = ex_rep +1)) # Update the sim_scheme with a new seed to re-launch the simulation
+                                df = pd.DataFrame.from_dict(data=param_list_dict, orient='columns')
+                                df.to_csv(path_or_buf=scheme, sep='\t', index=False) # Create the csv file sim_scheme to launch the simulation
+                                p = Popen(["walter", "-i", scheme]) # Launch the simulation
+                                prj.itable.update(sim_id = param_list_dict[0]) # updating combi_param
+                                prj.update_itable()
+                                pids.append(p) # Add the new process to the list of processes for futher testing
+                                procs[scheme] = p # Add the new process to the dict of processes
+                    sleep 1 minute # To avoid testing for finished processes too often, wait between loops
                                 
                 tmp.rmtree()
 

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -31,6 +31,7 @@ WALTer generates a project directory and run simulations inside this directory.
         or
        walter -i
 
+
 3. To run project management only, without running te model (for debug)  
 
        walter -i sim_scheme.csv -p simu_walter --dry_run 
@@ -52,6 +53,7 @@ def main():
 
     parser = walter_parser()
     args = parser.parse_args()
+
 
     if args.p == '.':  # check '.' is walter-like (in case user has  forgotten -p)
         if not project.check_cwd():

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -89,7 +89,8 @@ def main():
                 procs = {}
                 active_procs = []
                 for i, pdict in enumerate(param_list):
-                    while len(active_procs) > 2: # As long as there are 3 active_procs, test if one ends
+                    ############################################# temporary fix #############################################################################################
+                    while len(active_procs) > 2: # As long as there are 3 active_procs, test if one ends : temporary fix to avoid running too many processes at the same time
                         active_procs = [proc for proc in active_procs if proc.poll() == None]
                         time.sleep(300) # To avoid testing for finished processes too often, wait 5 minutes between loops
                     df = pd.DataFrame.from_dict(data=[pdict], orient='columns')
@@ -100,7 +101,8 @@ def main():
                     pids.append(pid)
                     procs[scheme_name] = pid
                     active_procs.append(pid)
-                # Test caribuRunError re-launching
+                ############################################# temporary fix #############################################################################################
+                # Test caribuRunError re-launching : temporary fix until CaribuRunErrors are solved
                 while len(procs) > 0: # While there are processes to test
                     for scheme in procs.keys(): #Not using iteritems because you cannot change the size of a dictionary while iterating on it
                         if procs[scheme].poll() != None: # If the proces is finished

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -81,6 +81,7 @@ def main():
                 if not tmp.exists():
                     tmp.mkdir()
                 pids = []
+                procs = {}
                 for i, pdict in enumerate(param_list):
                     df = pd.DataFrame.from_dict(data=[pdict], orient='columns')
                     scheme_name = str(tmp / 'sim_scheme_%d.csv' % (i + 1))
@@ -88,7 +89,28 @@ def main():
                     prj.activate()
                     pid = Popen(["walter", "-i", scheme_name])
                     pids.append(pid)
+                    procs[pid] = scheme_name
                 for pid in pids:
                     pid.wait()
+                #~ # Test caribuRunError re-launching
+                #~ while len(procs) > 0:
+                    #~ for proc, scheme in procs.iteritems:
+                        #if proc.poll() != None:
+                            # remove this proc from procs
+                            #procs.pop(proc)
+                            #param_list_dict = prj.csv_parameters(scheme)
+                            # Recupere ID
+                            #sim_id = prj.get_id(param_list_dict[0])
+                            #if os.path.exists(prj.dirname/output/sim_id/error_caribu.txt): # Check if the file error_caribu.txt has been generated
+                                #ex_rep = param_list_dict[0]["rep"]
+                                #param_list_dict[0].update(rep = ex_rep +1))
+                                #df = pd.DataFrame.from_dict(data=param_list_dict, orient='columns')
+                                #df.to_csv(path_or_buf=scheme, sep='\t', index=False)
+                                #p=popen(["walter", "-i", scheme])
+                                #prj.itable.update(sim_id=param_list_dict[0])
+                                #prj.update_itable()
+                                #procs.append(p)
+                    #sleep 1 minute
+                                
                 tmp.rmtree()
 

--- a/src/walter/command_line.py
+++ b/src/walter/command_line.py
@@ -109,6 +109,5 @@ def main():
                                 pids.append(p) # Add the new process to the list of processes for futher testing
                                 procs[scheme] = p # Add the new process to the dict of processes
                     time.sleep(120) # To avoid testing for finished processes too often, wait 2 minutes between loops
-                                
                 tmp.rmtree()
 

--- a/test/test_command_line.py
+++ b/test/test_command_line.py
@@ -1,6 +1,7 @@
 import os
 from shutil import rmtree, copy
 from walter.command_line import walter_parser
+
 call_dir = os.getcwd()
 
 
@@ -19,7 +20,6 @@ def test_parser():
     args = parser.parse_args('-p my_project -i my_sim'.split())
     assert args.p == 'my_project'
     assert args.i == 'my_sim'
-
 
 def test_one_sim():
     reset_call_dir()


### PR DESCRIPTION
Since we've made modifications on WALTer, CaribuRunErrors are very rare. However, they still happen and we are not a 100% sure to know how to avoid them. Until we have solved this problem for good, we can't afford to spend time managing the simulations, selecting the ones that worked and re-running the ones with errors.
This is why Franck Gauthier and I have worked on these lines to automatically re-run simulations with a different random seed in case of a CaribuRunError.