### PR TITLE
Turtle sky

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - alinea.caribu
     - boost >=1.66
     - openalea.lpy
+    - alinea.astk
 
 test:
   requires:

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -28,8 +28,8 @@ def get_light(current_PAR, nb_azimuth, nb_zenith):
     return sky_tup
 
 
-def get_turtle_light(current_PAR, sky_type='soc', turtle_sectors=46, add_sun=False, curent_date=None, longitude = _longitude, latitude=_latitude,
-                altitude=_altitude, timezone=_timezone):
+def get_turtle_light(current_PAR, sky_type='soc', turtle_sectors=46, add_sun=False, curent_date=None,
+                     longitude = _longitude, latitude=_latitude, altitude=_altitude, timezone=_timezone):
     """Sun + sky source using the 46 sector turtle sky discretisation
         Args:
         current_date: a naive datetime object
@@ -37,12 +37,14 @@ def get_turtle_light(current_PAR, sky_type='soc', turtle_sectors=46, add_sun=Fal
                            'soc' (standard overcast sky),
                            'uoc' (uniform overcast sky)
                            'clear_sky' (standard clear sky)
+        turtle_sectors : (int) the minimal number of sectors to be used for discretising the sky hemisphere. Turtle
+        discretisation will be one of 1, 6, 16 or 46 sectors
         longitude: (float) in degrees
         latitude: (float) in degrees
         altitude: (float) in meter
         timezone:(str) the time zone
-"""
-    daydate='2000-06-21'
+    """
+    daydate = '2000-06-21'
     if curent_date is not None:
         daydate = curent_date.strftime('%Y-%m-%d')
     sun = [(), (), ()]
@@ -55,8 +57,8 @@ def get_turtle_light(current_PAR, sky_type='soc', turtle_sectors=46, add_sun=Fal
         sun = sun_sources(irradiance=f_sun * current_PAR,
                           daydate=daydate, latitude=latitude, longitude=longitude,
                           altitude=altitude, timezone=timezone)
-    sky = sky_sources(sky_type=sky_type, irradiance=current_PAR * (1 - f_sun), daydate=daydate, longitude = longitude, latitude=latitude,
-                altitude=altitude, timezone=timezone)
+    sky = sky_sources(sky_type=sky_type, irradiance=current_PAR * (1 - f_sun), turtle_sectors=turtle_sectors,
+                      daydate=daydate, longitude = longitude, latitude=latitude, altitude=altitude, timezone=timezone)
     return light_sources(*sky) + light_sources(*sun)
 
 

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -3,7 +3,7 @@ Walter"""
 from alinea.caribu.sky_tools import GenSky, GetLight
 from alinea.caribu.CaribuScene import CaribuScene
 from alinea.caribu.light import light_sources
-from alinea.astk.sun_and_sky import sun_sources, sky_sources, _timezone, _longitude, _latitude, _altitude
+from alinea.astk.sun_and_sky import sun_sources, sun_fraction, sky_irradiances, sky_sources, _timezone, _longitude, _latitude, _altitude
 
 
 def scene_pattern(crop_scheme):
@@ -46,9 +46,16 @@ def get_turtle_light(current_PAR, sky_type='soc', add_sun=False, curent_date=Non
     if curent_date is not None:
         daydate = curent_date.strftime('%Y-%m-%d')
     sun = [(), (), ()]
+    f_sun = 0
     if add_sun:
-        pass
-    sky = sky_sources(sky_type=sky_type, irradiance=current_PAR, daydate=daydate, longitude = longitude, latitude=latitude,
+        sky_irr = sky_irradiances(daydate=daydate, longitude=longitude,
+                                  latitude=latitude, altitude=altitude,
+                                  timezone=timezone)
+        f_sun = sun_fraction(sky_irr)
+        sun = sun_sources(irradiance=f_sun * current_PAR,
+                          daydate=daydate, latitude=latitude, longitude=longitude,
+                          altitude=altitude, timezone=timezone)
+    sky = sky_sources(sky_type=sky_type, irradiance=current_PAR * (1 - f_sun), daydate=daydate, longitude = longitude, latitude=latitude,
                 altitude=altitude, timezone=timezone)
     return light_sources(*sky) + light_sources(*sun)
 

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -91,5 +91,5 @@ def caribu_scene(lscene, crop_scheme, current_PAR):
 
     """
     pattern = scene_pattern(crop_scheme)
-    return CaribuScene(scene=lscene, scene_unit="cm", light=light,
+    return CaribuScene(scene=lscene, scene_unit="cm", light=current_PAR,
                        pattern=pattern)

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -77,7 +77,7 @@ class CaribuRecorder(object):
                         (resolution, ldiag, pixel_per_cm, pixel_per_triangle, confidence)))
 
 
-def caribu_scene(lscene, crop_scheme, current_PAR, nb_azimuth, nb_zenith):
+def caribu_scene(lscene, crop_scheme, current_PAR):
     """Create a caribu scene from walter lscene
 
     Args:

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -3,7 +3,7 @@ Walter"""
 from alinea.caribu.sky_tools import GenSky, GetLight
 from alinea.caribu.CaribuScene import CaribuScene
 from alinea.caribu.light import light_sources
-from alinea.astk.sun_and_sky import sun_sky_sources
+from alinea.astk.sun_and_sky import sun_sources, sky_sources
 
 
 def scene_pattern(crop_scheme):
@@ -28,15 +28,10 @@ def get_light(current_PAR, nb_azimuth, nb_zenith):
     return sky_tup
 
 
-def get_turtle_light(current_PAR):
+def get_turtle_light(current_PAR, curent_date=None):
     """Sun + sky source using the 46 sector turtle sky discretisation"""
-    # parameter for soc sky (like get_light). More realistic skies can be obtained
-    ghi = current_PAR
-    dhi = ghi # force sun = 0
-    _ , sky = sun_sky_sources(ghi, dhi, model='sun_soc')
-    sun = [[],[],[]]
-
-    return light_sources(*sun) + light_sources(*sky)
+    sky = sky_sources(sky_type='soc', irradiance=current_PAR)
+    return light_sources(*sky)
 
 
 def caribu_scene(lscene, crop_scheme, light):

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -28,7 +28,7 @@ def get_light(current_PAR, nb_azimuth, nb_zenith):
     return sky_tup
 
 
-def get_turtle_light(current_PAR, sky_type='soc', add_sun=False, curent_date=None, longitude = _longitude, latitude=_latitude,
+def get_turtle_light(current_PAR, sky_type='soc', turtle_sectors=46, add_sun=False, curent_date=None, longitude = _longitude, latitude=_latitude,
                 altitude=_altitude, timezone=_timezone):
     """Sun + sky source using the 46 sector turtle sky discretisation
         Args:

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -3,7 +3,7 @@ Walter"""
 from alinea.caribu.sky_tools import GenSky, GetLight
 from alinea.caribu.CaribuScene import CaribuScene
 from alinea.caribu.light import light_sources
-from alinea.astk.sun_and_sky import sun_sources, sky_sources
+from alinea.astk.sun_and_sky import sun_sources, sky_sources, _timezone, _longitude, _latitude, _altitude
 
 
 def scene_pattern(crop_scheme):
@@ -28,10 +28,29 @@ def get_light(current_PAR, nb_azimuth, nb_zenith):
     return sky_tup
 
 
-def get_turtle_light(current_PAR, curent_date=None):
-    """Sun + sky source using the 46 sector turtle sky discretisation"""
-    sky = sky_sources(sky_type='soc', irradiance=current_PAR)
-    return light_sources(*sky)
+def get_turtle_light(current_PAR, sky_type='soc', add_sun=False, curent_date=None, longitude = _longitude, latitude=_latitude,
+                altitude=_altitude, timezone=_timezone):
+    """Sun + sky source using the 46 sector turtle sky discretisation
+        Args:
+        current_date: a naive datetime object
+        sky_type:(str) type of sky luminance model. One of :
+                           'soc' (standard overcast sky),
+                           'uoc' (uniform overcast sky)
+                           'clear_sky' (standard clear sky)
+        longitude: (float) in degrees
+        latitude: (float) in degrees
+        altitude: (float) in meter
+        timezone:(str) the time zone
+"""
+    daydate='2000-06-21'
+    if curent_date is not None:
+        daydate = curent_date.strftime('%Y-%m-%d')
+    sun = [(), (), ()]
+    if add_sun:
+        pass
+    sky = sky_sources(sky_type=sky_type, irradiance=current_PAR, daydate=daydate, longitude = longitude, latitude=latitude,
+                altitude=altitude, timezone=timezone)
+    return light_sources(*sky) + light_sources(*sun)
 
 
 def caribu_scene(lscene, crop_scheme, light):

--- a/src/walter/light.py
+++ b/src/walter/light.py
@@ -2,6 +2,8 @@
 Walter"""
 from alinea.caribu.sky_tools import GenSky, GetLight
 from alinea.caribu.CaribuScene import CaribuScene
+from alinea.caribu.light import light_sources
+from alinea.astk.sun_and_sky import sun_sky_sources
 
 
 def scene_pattern(crop_scheme):
@@ -26,7 +28,18 @@ def get_light(current_PAR, nb_azimuth, nb_zenith):
     return sky_tup
 
 
-def caribu_scene(lscene, crop_scheme, current_PAR, nb_azimuth, nb_zenith):
+def get_turtle_light(current_PAR):
+    """Sun + sky source using the 46 sector turtle sky discretisation"""
+    # parameter for soc sky (like get_light). More realistic skies can be obtained
+    ghi = current_PAR
+    dhi = ghi # force sun = 0
+    _ , sky = sun_sky_sources(ghi, dhi, model='sun_soc')
+    sun = [[],[],[]]
+
+    return light_sources(*sun) + light_sources(*sky)
+
+
+def caribu_scene(lscene, crop_scheme, light):
     """Create a caribu scene from walter lscene
 
     Args:
@@ -39,7 +52,6 @@ def caribu_scene(lscene, crop_scheme, current_PAR, nb_azimuth, nb_zenith):
     Returns:
 
     """
-    sky = get_light(current_PAR, nb_azimuth, nb_zenith)
     pattern = scene_pattern(crop_scheme)
-    return CaribuScene(scene=lscene, scene_unit="cm", light=sky,
+    return CaribuScene(scene=lscene, scene_unit="cm", light=light,
                        pattern=pattern)

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -970,7 +970,14 @@ for geno in crop_genotype:
 # Parametres communs
 #######################
 
-radiation_type    = "diffuse" #or {"diffuse"; "complete"}
+radiation_type    = "sun_soc" # Parameter for the get_turtle_light function (diffuse or direct light)
+sky_sector_number = 46 # Parameter for the get_turtle_light function (number of sectors in the sky). Choices are : 1, 5, 16 or 46
+
+var_registerTurtleSky = ["radiation_type", "sky_sector_number"]
+for key, value, in params.iteritems():
+  if key in var_registerTurtleSky:
+    exec(key+"=value")
+
 PAS               = 24
 
 ##
@@ -2642,6 +2649,7 @@ def End(lstring):
                        "CARIBU_state" + "\t" + "All" + "\t" + "%s" % CARIBU_state + "\n" +
                        "SIRIUS_state" + "\t" + "All" + "\t" + "%s" % SIRIUS_state + "\n" +
                        "Radiation_type" + "\t" + "All" + "\t" + "%s" % radiation_type + "\n" +
+                       "sky_sector_number" + "\t" + "All" + "\t" + "%s" % sky_sector_number + "\n" +
                        "infinity_GAIp"  + "\t" + "All" + "\t" + "%s" % infinity_GAIp + "\n" +
                        "infinity_CARIBU" + "\t" + "All" + "\t" + "%s" % infinity_CARIBU + "\n" +
                        "Light_step" + "\t" + "All" + "\t" + "%s" % PAS + "\n" +

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -973,11 +973,11 @@ for geno in crop_genotype:
 # Parametres communs
 #######################
 
-radiation_type    = "sun_soc" # Parameter for the get_turtle_light function (diffuse or direct light)
+sky_type    = "soc" # Parameter for type of sky : 'soc' (overcast sky) or 'clear_sky'
 sky_sector_number = 46 # Parameter for the get_turtle_light function (number of sectors in the sky). Choices are : 1, 5, 16 or 46
-add_sun = False
+add_sun = 0 # trigger the addition of one sun position per hour in the light sources
 
-var_registerTurtleSky = ["radiation_type", "sky_sector_number", "add_sun"]
+var_registerTurtleSky = ["sky_type", "sky_sector_number", "add_sun"]
 for key, value, in params.iteritems():
   if key in var_registerTurtleSky:
     exec(key+"=value")
@@ -2391,7 +2391,12 @@ def EndEach(lstring, lscene):
           print "The date : ", str(datetime.datetime.now())
           # light = get_light(current_PAR, nb_azimuth, nb_zenith)
           # 46 direction sky
-          light = get_turtle_light(current_PAR)
+          longi = dico_longitudes[location]
+          lat = dico_latitudes[location]
+          alt = dico_altitude[location]
+          tz = dico_time_zone[location]
+          light = get_turtle_light(current_PAR, sky_type='soc', add_sun=bool(add_sun), curent_date=date_current_day,
+                                   longitude=longi, latitude=lat, altitude=alt, timezone=tz)
           c_scene = caribu_scene(lscene, crop_scheme, light)
           res_sky= None
           try:

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -2689,7 +2689,7 @@ def End(lstring):
                        "Genotypes_nb" + "\t" + "All" + "\t" + "%s" % geno_nb + "\n" +
                        "CARIBU_state" + "\t" + "All" + "\t" + "%s" % CARIBU_state + "\n" +
                        "SIRIUS_state" + "\t" + "All" + "\t" + "%s" % SIRIUS_state + "\n" +
-                       "Radiation_type" + "\t" + "All" + "\t" + "%s" % radiation_type + "\n" +
+                       "sky_type" + "\t" + "All" + "\t" + "%s" % sky_type + "\n" +
                        "sky_sector_number" + "\t" + "All" + "\t" + "%s" % sky_sector_number + "\n" +
                        "infinity_GAIp"  + "\t" + "All" + "\t" + "%s" % infinity_GAIp + "\n" +
                        "infinity_CARIBU" + "\t" + "All" + "\t" + "%s" % infinity_CARIBU + "\n" +

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -37,7 +37,7 @@ except NameError:
 ### Rayonnement ###
 #from vplants.fractalysis.light.directLight import diffuseInterception      #Importation de Fractalysis : obsolete
 
-from walter.light import caribu_scene
+from walter.light import caribu_scene, get_light, get_turtle_light
 
 # CPL
 from collections import defaultdict
@@ -2372,8 +2372,10 @@ def EndEach(lstring, lscene):
       if len(lscene) > 0:
         if beginning_CARIBU < Tempcum < ending_CARIBU:
           print "The date : ", str(datetime.datetime.now())
-
-          c_scene = caribu_scene(lscene, crop_scheme, current_PAR, nb_azimuth, nb_zenith)
+          # light = get_light(current_PAR, nb_azimuth, nb_zenith)
+          # 46 direction sky
+          light = get_turtle_light(current_PAR)
+          c_scene = caribu_scene(lscene, crop_scheme, light)
           res_sky= None
           try:
             _, res_sky = c_scene.run(simplify=True, infinite = bool(infinity_CARIBU), direct = True)

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -2395,7 +2395,7 @@ def EndEach(lstring, lscene):
           lat = dico_latitudes[location]
           alt = dico_altitude[location]
           tz = dico_time_zone[location]
-          light = get_turtle_light(current_PAR, sky_type='soc', add_sun=bool(add_sun), curent_date=date_current_day,
+          light = get_turtle_light(current_PAR, sky_type=sky_type, add_sun=bool(add_sun), curent_date=date_current_day,
                                    longitude=longi, latitude=lat, altitude=alt, timezone=tz)
           c_scene = caribu_scene(lscene, crop_scheme, light)
           res_sky= None

--- a/src/walter_data/WALTer.lpy
+++ b/src/walter_data/WALTer.lpy
@@ -974,10 +974,10 @@ for geno in crop_genotype:
 #######################
 
 sky_type    = "soc" # Parameter for type of sky : 'soc' (overcast sky) or 'clear_sky'
-sky_sector_number = 46 # Parameter for the get_turtle_light function (number of sectors in the sky). Choices are : 1, 5, 16 or 46
+turtle_sectors = 46 # Parameter for the get_turtle_light function (number of sectors in the sky). Choices are : 1, 5, 16 or 46
 add_sun = 0 # trigger the addition of one sun position per hour in the light sources
 
-var_registerTurtleSky = ["sky_type", "sky_sector_number", "add_sun"]
+var_registerTurtleSky = ["sky_type", "turtle_sectors", "add_sun"]
 for key, value, in params.iteritems():
   if key in var_registerTurtleSky:
     exec(key+"=value")
@@ -2395,8 +2395,8 @@ def EndEach(lstring, lscene):
           lat = dico_latitudes[location]
           alt = dico_altitude[location]
           tz = dico_time_zone[location]
-          light = get_turtle_light(current_PAR, sky_type=sky_type, add_sun=bool(add_sun), curent_date=date_current_day,
-                                   longitude=longi, latitude=lat, altitude=alt, timezone=tz)
+          light = get_turtle_light(current_PAR, sky_type=sky_type, turtle_sectors=turtle_sectors, add_sun=bool(add_sun),
+                                   curent_date=date_current_day, longitude=longi, latitude=lat, altitude=alt, timezone=tz)
           c_scene = caribu_scene(lscene, crop_scheme, light)
           res_sky= None
           try:
@@ -2690,7 +2690,7 @@ def End(lstring):
                        "CARIBU_state" + "\t" + "All" + "\t" + "%s" % CARIBU_state + "\n" +
                        "SIRIUS_state" + "\t" + "All" + "\t" + "%s" % SIRIUS_state + "\n" +
                        "sky_type" + "\t" + "All" + "\t" + "%s" % sky_type + "\n" +
-                       "sky_sector_number" + "\t" + "All" + "\t" + "%s" % sky_sector_number + "\n" +
+                       "turtle_sectors" + "\t" + "All" + "\t" + "%s" % turtle_sectors + "\n" +
                        "infinity_GAIp"  + "\t" + "All" + "\t" + "%s" % infinity_GAIp + "\n" +
                        "infinity_CARIBU" + "\t" + "All" + "\t" + "%s" % infinity_CARIBU + "\n" +
                        "Light_step" + "\t" + "All" + "\t" + "%s" % PAS + "\n" +

--- a/test/test_light.py
+++ b/test/test_light.py
@@ -33,3 +33,7 @@ def test_get_turtle_light():
     nrj, dir = zip(*get_turtle_light(par, curent_date=d, sky_type='clear_sky'))
     assert_almost_equal(sum(nrj), 1)
     assert len(nrj) == 46
+
+    nrj, dir = zip(*get_turtle_light(par, curent_date=d, sky_type='clear_sky', add_sun=True))
+    assert_almost_equal(sum(nrj), 1)
+    assert len(nrj) == 57

--- a/test/test_light.py
+++ b/test/test_light.py
@@ -1,0 +1,29 @@
+"""Test light/sky function and connection with walter date / meteo data"""
+
+import datetime
+from walter.light import get_light, get_turtle_light
+from nose.tools import assert_almost_equal
+
+
+def walter_dates(sowing_date=datetime.date(1998,10,15), iterations=1):
+    """generate dates like walter.lpy over time"""
+    dd = [sowing_date + datetime.timedelta(elapsed_time) for elapsed_time in range(iterations)]
+    if iterations == 1:
+        return dd[0]
+    else:
+        return dd
+
+
+def test_get_turtle_light():
+    par = 1
+    d = walter_dates()
+    nrj0, dir0 = zip(*get_light(par, 4, 5))
+    nrj, dir = zip(*get_turtle_light(par))
+    assert_almost_equal(sum(nrj0), 1)
+    assert_almost_equal(sum(nrj), 1)
+
+    par = 10
+    nrj0, dir0 = zip(*get_light(par, 4, 5))
+    nrj, dir = zip(*get_turtle_light(par))
+    assert_almost_equal(sum(nrj0), 10)
+    assert_almost_equal(sum(nrj), 10)

--- a/test/test_light.py
+++ b/test/test_light.py
@@ -27,3 +27,9 @@ def test_get_turtle_light():
     nrj, dir = zip(*get_turtle_light(par))
     assert_almost_equal(sum(nrj0), 10)
     assert_almost_equal(sum(nrj), 10)
+
+    par = 1
+    nrj_soc, _ = zip(*get_turtle_light(par))
+    nrj, dir = zip(*get_turtle_light(par, curent_date=d, sky_type='clear_sky'))
+    assert_almost_equal(sum(nrj), 1)
+    assert len(nrj) == 46

--- a/test/test_light_interception.py
+++ b/test/test_light_interception.py
@@ -67,16 +67,17 @@ def test_infinite():
     p.remove(force=True)
 
 
-def check_light_balance():
+def test_check_light_balance():
     """test if total par intercepted is above or below incident par"""
     p = project.Project(name='light_balance')
     params = p.csv_parameters('sim_scheme_test.csv')[0]
-    params.update(dict(write_debug_PAR=True,infinity_CARIBU=0))
+    params.update(dict(write_debug_PAR=True, infinity_CARIBU=1))
     lsys, lstring = p.run(**params)
     crop_scheme = lsys.context().locals()['crop_scheme']
     df = pandas.DataFrame(lsys.context().locals()['Debug_PAR_dico_df'])
     control = df.groupby('Elapsed_time').agg({'Organ_PAR':'sum', 'Inc_PAR':'mean'})
     balance = control.Organ_PAR / control.Inc_PAR / crop_scheme['surface_sol']
+    assert all(balance <= 1)
     p.remove(force=True)
 
 


### PR DESCRIPTION
Add import of 46 sector sky discretisation (close #60)

@Emblanc :the 46 sky model could be used as the previous one, ie using a soc sky radiance model (current state), or used together with meteo data and geographical location to have more realistic skies (clear sky, sun, ...) 